### PR TITLE
Player open button propose to browsing starting from the download folder

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -427,8 +427,12 @@ void MainWindow::btnMenuClick() {
     if (btn == ui->btnArchive->objectName())
         ui->stackedWidget->setCurrentWidget(archivePage);
 
-    if (btn == ui->btnStreaming->objectName())
+    if (btn == ui->btnStreaming->objectName()) {
+        if (previewPlayerPage && settingsPage) {
+            previewPlayerPage->setDownloadPath(settingsPage->getDownloadPath());
+        }
         ui->stackedWidget->setCurrentWidget(previewPlayerPage);
+    }
 
     if (btn == ui->btnStatistics->objectName())
         ui->stackedWidget->setCurrentWidget(statisticsPage);

--- a/src/previewplayerwindow.cpp
+++ b/src/previewplayerwindow.cpp
@@ -64,11 +64,15 @@ PreviewPlayerWindow::~PreviewPlayerWindow()
 
 void PreviewPlayerWindow::on_pushButtonOpenFile_clicked()
 {
-    QString fileName = QFileDialog::getOpenFileName(this, "Open Video Stream", QDir::currentPath(), "Video Files (*.mkv *.avi *.mp4 *.mov *.wmv)");
-    if(fileName != "")
-    {
+    // Propose download folder as starting path
+
+    QString fileName = QFileDialog::getOpenFileName(this,
+                                                    tr("Open Video Stream"),
+                                                    (!m_downloadPath.isEmpty() ? m_downloadPath : QDir::currentPath()),
+                                                    QString("%1 (*.mkv *.avi *.mp4 *.mov *.wmv)").arg(tr("Video Files")));
+    if (!fileName.isEmpty()) {
         previewPlayer->playFile(fileName);
-        this->updatePlayPauseButton();
+        updatePlayPauseButton();
     }
 }
 

--- a/src/previewplayerwindow.h
+++ b/src/previewplayerwindow.h
@@ -19,6 +19,9 @@ public:
     ~PreviewPlayerWindow();
 
     void PauseForHidden();
+
+    void setDownloadPath(const QString& pathToSet) {m_downloadPath = pathToSet;}
+
 protected:
     //void keyPressEvent(QKeyEvent *e);
     bool eventFilter(QObject *obj, QEvent *event);
@@ -31,6 +34,7 @@ private slots:
     void on_pushButtonFullscreen_clicked();
 
 private:
+    QString m_downloadPath;
     Ui::PreviewPlayerWindow *ui = Q_NULLPTR;
     QSlider * seekSlider = Q_NULLPTR;
     PreviewPlayer *previewPlayer = Q_NULLPTR;


### PR DESCRIPTION
Not a fix, just something that can be considered useful: when pushing the open button from the preview/player window, the classic browse dialog box propose the download folder as the "starting point" for the browsing.